### PR TITLE
To fix bug #55

### DIFF
--- a/assets/treeval_test.yaml
+++ b/assets/treeval_test.yaml
@@ -6,13 +6,13 @@ assembly:
   asmVersion: PB.a1
   dbVersion: "1"
   gevalType: DTOL
-reference_file: /lustre/scratch123/tol/teams/grit/geval_pipeline/geval_runs/DTOL/nxOscDoli1_1/data/DTOL_nxOscDoli1_1_FULL.fa
+reference_file: /lustre/scratch123/tol/teams/grit/geval_pipeline/geval_runs/DTOL/nxAuaSpej2_1/raw/nxAuaSpej2_hifiasm.notelos.20220902.decontaminated.fa
 assem_reads:
   pacbio: path
   hic: path
   supplementary: path
 alignment:
-  data_dir: /nfs/team135/dp24/treeval_testdata/gene_alignment_data/
+  data_dir: /lustre/scratch123/tol/resources/treeval/gene_alignment_data/
   common_name: "" # For future implementation (adding bee, wasp, ant etc)
   geneset: "Gae_host.Gae,CSKR_v2.CSKR"
   #Path should end up looking like "{data_dir}{classT}/{common_name}/csv_data/{geneset}-data.csv"
@@ -20,7 +20,7 @@ self_comp:
   motif_len: 0
   mummer_chunk: 10
 synteny:
-  synteny_genome_path: "/nfs/team135/dp24/treeval_testdata/synteny_data"
+  synteny_genome_path: /lustre/scratch123/tol/resources/treeval/synteny/
 outdir: "NEEDS TESTING"
 intron:
   size: "50k"

--- a/modules/local/csv_pull.nf
+++ b/modules/local/csv_pull.nf
@@ -1,5 +1,5 @@
 process CSV_PULL {
-    tag "${ch_org}"
+    tag "${csv_loc}"
     label 'process_low'
 
     conda "conda-forge::coreutils=9.1"
@@ -8,11 +8,10 @@ process CSV_PULL {
     'ubuntu:20.04' }"
 
     input:
-    val ch_org
     path csv_loc
 
     output:
-    path "${ch_org}-data.csv",      emit: csv
+    path "${csv_loc}",      emit: csv
 
     script:
     """

--- a/subworkflows/local/gene_alignment.nf
+++ b/subworkflows/local/gene_alignment.nf
@@ -39,6 +39,8 @@ workflow GENE_ALIGNMENT {
         .combine( alignment_datadir )
         .combine( assembly_classT )
         .set { csv_input } 
+    
+
     //
     // MODULE: CONVERTS THE ABOVE VALUES INTO A STRING REPRESENTATIVE OF THE PATH
     //
@@ -50,8 +52,8 @@ workflow GENE_ALIGNMENT {
     // MODULE: USES THE ABOVE STRING AND CONVERTS TO PATH OBJECT
     //         IF S3; DOWNLOADS ;ELIF LOCAL; PASS
     //
-    CSV_PULL (          csv_input.map { it[0] },
-                        CSV_GENERATOR.out.csv_path )
+    CSV_PULL (          CSV_GENERATOR.out.csv_path )
+
     //
     // LOGIC: CONVERTS THE PATH OBJECT INTO A TUPLE OF
     //          [ [ META.ID, META.TYPE, META.ORG ], GENE_ALIGNMENT_FILE ]


### PR DESCRIPTION
During testing today we found a bug caused by the CSV_PULL module, I has recently begun mixing it's input channels with another instance of the module, e.g, the module was being run twice with the correct input values and yet the module would pull a variable from another instance. This resulted in the pipeline failing due to incorrect output files.

This has now been corrected, by removing 1 of the inputs which is not needed for the running of the pipeline.

The pipeline passes the local tests and s3 tests will be fixed in the future.

nf-core lint passes

prettier is failing due to local node-14 requirements