### PR TITLE
Outdir correction

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -22,14 +22,8 @@ process {
         memory = { check_max( 50.GB     * task.attempt, 'memory') }
     }
 
-    withName:SELFCOMP_ALIGNMENTBLOCKS {
-        cpus    = { check_max( 2        * task.attempt, 'cpus'  ) }
-        memory  = { check_max( 60.GB    * task.attempt, 'memory') }
-        time    = { check_max( 8.h      * task.attempt, 'time'  ) }
-    }
-
-    withName: '.*:.*:SELFCOMP:BEDTOOLS_MERGE' {
-        cpus    = { check_max( 2        * task.attempt, 'cpus'  ) }
+    withName: '.*:.*:SELFCOMP:(SELFCOMP_ALIGNMENTBLOCKS|SELFCOMP_MAPIDS|SELFCOMP_MUMMER2BED|SELFCOMP_SPLITFASTA)' {
+        cpus    = { check_max( 1        * task.attempt, 'cpus'  ) }
         memory  = { check_max( 60.GB    * task.attempt, 'memory') }
         time    = { check_max( 8.h      * task.attempt, 'time'  ) }
     }

--- a/conf/base.config
+++ b/conf/base.config
@@ -24,7 +24,13 @@ process {
 
     withName:SELFCOMP_ALIGNMENTBLOCKS {
         cpus    = { check_max( 2        * task.attempt, 'cpus'  ) }
-        memory  = { check_max( 50.GB    * task.attempt, 'memory') }
+        memory  = { check_max( 60.GB    * task.attempt, 'memory') }
+        time    = { check_max( 8.h      * task.attempt, 'time'  ) }
+    }
+
+    withName: '.*:.*:SELFCOMP:BEDTOOLS_MERGE' {
+        cpus    = { check_max( 2        * task.attempt, 'cpus'  ) }
+        memory  = { check_max( 60.GB    * task.attempt, 'memory') }
         time    = { check_max( 8.h      * task.attempt, 'time'  ) }
     }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -22,6 +22,12 @@ process {
         memory = { check_max( 50.GB     * task.attempt, 'memory') }
     }
 
+    withName:SELFCOMP_ALIGNMENTBLOCKS {
+        cpus    = { check_max( 2        * task.attempt, 'cpus'  ) }
+        memory  = { check_max( 50.GB    * task.attempt, 'memory') }
+        time    = { check_max( 8.h      * task.attempt, 'time'  ) }
+    }
+
     // 20GB * (task attempt * 2) = 40GB, 80GB, 120GB
     withName:MUMMER {
         cpus    = { check_max( 12        * task.attempt, 'cpus'                      ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,11 +12,13 @@
 
 process {
 
+    /*
     publishDir = [
         path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
+    */
 
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
@@ -26,7 +28,20 @@ process {
         ]
     }
 
+    withName: GENERATE_GENOME_FILE {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: BEDTOOLS_SORT {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
         ext.prefix  = { "${meta.id}.sorted" }
     }
 
@@ -34,18 +49,39 @@ process {
         ext.args    = "-u --gff -j 1"
     }
 
+    withName: TABIX_BGZIPTABIX {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*:.*:NUC_ALIGNMENTS:MINIMAP2_ALIGN' {
+        ext.args    = {"-ax splice ${meta.intron_size ? "-G ${meta.intron_size}" : ""}"}
+        ext.prefix  = { "${meta.id}_alignment_${reference.getName().tokenize('.')[0]}" }
+    }
+
     withName: '.*:.*:.*:NUC_ALIGNMENTS:BEDTOOLS_BAMTOBED' {
         ext.args        = "-bed12"
     }
 
-    withName: '.*:.*:INSILICO_DIGEST:UCSC_BEDTOBIGBED' {
-        ext.args        = { "-type=bed4+1 -extraIndex=length" }
-        ext.prefix      = { "${meta.id}" }
+    withName: UCSC_BEDTOBIGBED {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
 
-    withName: '.*:.*:SELFCOMP:UCSC_BEDTOBIGBED' {
-        ext.args    = { " -type=bed3+3 -extraIndex=qName,qStart,qEnd" }
-        ext.prefix  = { "${meta.id}" }
+    withName: '.*:.*:INSILICO_DIGEST:UCSC_BEDTOBIGBED' {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args        = { "-type=bed4+1 -extraIndex=length" }
+        ext.prefix      = { "${meta.id}" }
     }
 
     withName: '.*:.*:SELFCOMP:BEDTOOLS_MERGE' {
@@ -53,14 +89,24 @@ process {
         ext.prefix  = { "${meta.id}" }
     }
 
-    withName: '.*:.*:SYNTENY:MINIMAP2_ALIGN' {
-        ext.args    = '-t 8 -x asm10'
-        ext.prefix  = { "${meta.id}_synteny_${reference.getName().tokenize('.')[0]}" }
+    withName: '.*:.*:SELFCOMP:UCSC_BEDTOBIGBED' {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args    = { " -type=bed3+3 -extraIndex=qName,qStart,qEnd" }
+        ext.prefix  = { "${meta.id}" }
     }
 
-    withName: '.*:.*:NUC_ALIGNMENTS:MINIMAP2_ALIGN' {
-        ext.args    = {"-ax splice ${meta.intron_size ? "-G ${meta.intron_size}" : ""}"}
-        ext.prefix  = { "${meta.id}_alignment_${reference.getName().tokenize('.')[0]}" }
+    withName: '.*:.*:SYNTENY:MINIMAP2_ALIGN' {
+        publishDir = [
+            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args    = '-t 8 -x asm10'
+        ext.prefix  = { "${meta.id}_synteny_${reference.getName().tokenize('.')[0]}" }
     }
 
     withName : MUMMER {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,14 +12,6 @@
 
 process {
 
-    /*
-    publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    ]
-    */
-
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -28,7 +28,7 @@ process {
         ]
     }
 
-    withName: GENERATE_GENOME_FILE {
+    withName: 'GENERATE_GENOME_FILE|BEDTOOLS_SORT|TABIX_BGZIPTABIX|UCSC_BEDTOBIGBED' {
         publishDir = [
             path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
             mode: params.publish_dir_mode,
@@ -37,24 +37,11 @@ process {
     }
 
     withName: BEDTOOLS_SORT {
-        publishDir = [
-            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
         ext.prefix  = { "${meta.id}.sorted" }
     }
 
     withName: MINIPROT_ALIGN {
         ext.args    = "-u --gff -j 1"
-    }
-
-    withName: TABIX_BGZIPTABIX {
-        publishDir = [
-            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
     }
 
     withName: '.*:.*:NUC_ALIGNMENTS:MINIMAP2_ALIGN' {
@@ -64,14 +51,6 @@ process {
 
     withName: '.*:.*:.*:NUC_ALIGNMENTS:BEDTOOLS_BAMTOBED' {
         ext.args        = "-bed12"
-    }
-
-    withName: UCSC_BEDTOBIGBED {
-        publishDir = [
-            path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
     }
 
     withName: '.*:.*:INSILICO_DIGEST:UCSC_BEDTOBIGBED' {

--- a/modules/local/selfcomp_alignmentblocks.nf
+++ b/modules/local/selfcomp_alignmentblocks.nf
@@ -1,6 +1,8 @@
 process SELFCOMP_ALIGNMENTBLOCKS {
     tag "$meta.id"
     label 'process_single'
+    publishDir "", enabled: false
+
 
     conda "anaconda::pandas=1.4.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_alignmentblocks.nf
+++ b/modules/local/selfcomp_alignmentblocks.nf
@@ -1,8 +1,5 @@
 process SELFCOMP_ALIGNMENTBLOCKS {
     tag "$meta.id"
-    label 'process_medium'
-    publishDir "", enabled: false
-
 
     conda "anaconda::pandas=1.4.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_alignmentblocks.nf
+++ b/modules/local/selfcomp_alignmentblocks.nf
@@ -1,6 +1,6 @@
 process SELFCOMP_ALIGNMENTBLOCKS {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_medium'
     publishDir "", enabled: false
 
 

--- a/modules/local/selfcomp_mapids.nf
+++ b/modules/local/selfcomp_mapids.nf
@@ -1,6 +1,6 @@
 process SELFCOMP_MAPIDS {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_medium'
 
     conda "conda-forge::python=3.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_mapids.nf
+++ b/modules/local/selfcomp_mapids.nf
@@ -1,6 +1,5 @@
 process SELFCOMP_MAPIDS {
     tag "$meta.id"
-    label 'process_medium'
 
     conda "conda-forge::python=3.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_mummer2bed.nf
+++ b/modules/local/selfcomp_mummer2bed.nf
@@ -1,6 +1,6 @@
 process SELFCOMP_MUMMER2BED {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_medium'
 
     conda "conda-forge::python=3.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_mummer2bed.nf
+++ b/modules/local/selfcomp_mummer2bed.nf
@@ -1,6 +1,5 @@
 process SELFCOMP_MUMMER2BED {
     tag "$meta.id"
-    label 'process_medium'
 
     conda "conda-forge::python=3.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_splitfasta.nf
+++ b/modules/local/selfcomp_splitfasta.nf
@@ -1,6 +1,5 @@
 process SELFCOMP_SPLITFASTA {
     tag "$meta.id"
-    label 'process_medium'
 
     conda "conda-forge::perl-bioperl=1.7.8-1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/selfcomp_splitfasta.nf
+++ b/modules/local/selfcomp_splitfasta.nf
@@ -1,6 +1,6 @@
 process SELFCOMP_SPLITFASTA {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_medium'
 
     conda "conda-forge::perl-bioperl=1.7.8-1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
     genome                     = null
     igenomes_base              = null
     igenomes_ignore            = null
-    outdir                     = "./gene_alignment_results"
+    outdir                     = "./${outdir}"
     tracedir                   = "${params.outdir}/pipeline_info"
     publish_dir_mode           = 'copy'
     email                      = null


### PR DESCRIPTION
This pull request corrects the outdir setting, which has previously been hardcoded and has been where all files (intermediary and final) are saved to. SelfComp can generate tens of thousands of files, which may in the future require a quota check prior to the running of the pipeline, which are duplicated in the work and outdir locations.

This fix removed the duplication and allows the use of the `--outdir` flag.

This also corrects the process label on the self-comp modules to process_medium as they are intensive processes.

Fixes #69 
