### PR TITLE
Minor fixes

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -23,14 +23,14 @@ process {
 
     // RESOURCES: MEMORY INTENSIVE STEPS, SOFTWARE TO BE UPDATED TO COMBAT THIS
     withName: '.*:.*:SELFCOMP:(SELFCOMP_ALIGNMENTBLOCKS|SELFCOMP_MAPIDS|SELFCOMP_MUMMER2BED|SELFCOMP_SPLITFASTA|BEDTOOLS_MERGE)' {
-        cpus    = { check_max( 1        * task.attempt, 'cpus'  ) }
-        memory  = { check_max( 80.GB    * task.attempt, 'memory') }
+        cpus    = { check_max( 10       * task.attempt, 'cpus'  ) }
+        memory  = { check_max( 100.GB   * task.attempt, 'memory') }
         time    = { check_max( 8.h      * task.attempt, 'time'  ) }
     }
 
     // RESOURCES: CHANGES TO FREQUENT FAILURES BELOW THIS MEM POINT
     withName: '(MINIPROT_ALIGN|MINIMAP2_ALIGN)' {
-        memory = { check_max( 50.GB * task.attempt, 'memory'  ) }
+        memory = { check_max( 100.GB    * task.attempt, 'memory'  ) }
     }
 
     // 25GB * (task attempt * 2) = 50GB, 100GB, 150GB

--- a/subworkflows/local/gene_alignment.nf
+++ b/subworkflows/local/gene_alignment.nf
@@ -17,6 +17,7 @@ workflow GENE_ALIGNMENT {
     take:
     dot_genome          // Channel: [val(meta), [ datafile ]]
     reference_tuple
+    reference_index
     assembly_classT
     alignment_datadir
     alignment_genesets
@@ -78,16 +79,19 @@ workflow GENE_ALIGNMENT {
     // SUBWORKFLOW: GENERATES GENE ALIGNMENTS FOR RNA, NUCLEAR AND COMPLEMENT_DNA DATA, EMITS BIGBED
     //
     GEN_ALIGNMENTS (    reference_tuple,
+                        reference_index,
                         gen_files,
                         dot_genome,
                         intron_size )
     
     CDS_ALIGNMENTS (    reference_tuple,
+                        reference_index,
                         cds_files,
                         dot_genome,
                         intron_size )
     
     RNA_ALIGNMENTS (    reference_tuple,
+                        reference_index,
                         rna_files,
                         dot_genome,
                         intron_size )

--- a/subworkflows/local/generate_genome.nf
+++ b/subworkflows/local/generate_genome.nf
@@ -34,6 +34,7 @@ workflow GENERATE_GENOME {
  
     emit:
     dot_genome      = GENERATE_GENOME_FILE.out.dotgenome
+    ref_index       = SAMTOOLS_FAIDX.out.fai
     reference_tuple = to_samtools
 
     versions        = ch_versions.ifEmpty(null)

--- a/subworkflows/local/nuc_alignments.nf
+++ b/subworkflows/local/nuc_alignments.nf
@@ -9,6 +9,7 @@ include { UCSC_BEDTOBIGBED      } from '../../modules/nf-core/ucsc/bedtobigbed/m
 workflow NUC_ALIGNMENTS {
     take:
     reference_tuple
+    reference_index
     nuc_files
     dot_genome
     intron_size
@@ -42,13 +43,6 @@ workflow NUC_ALIGNMENTS {
         .set { formatted_input }
 
     //
-    // MODULE: GENERATES FASTA INDEX OF REFERENCE
-    //         EMITS FAIDX FILE
-    //
-    SAMTOOLS_FAIDX ( reference_tuple )
-    ch_versions     = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
-
-    //
     // MODULE: ALIGNS REFERENCE FAIDX TO THE GENE_ALIGNMENT QUERY FILE FROM NUC_FILES
     //         EMITS ALIGNED BAM FILE
     //
@@ -71,7 +65,7 @@ workflow NUC_ALIGNMENTS {
             tuple([id: meta.org, type: meta.type], file) } 
         .groupTuple( by: [0] )
         .combine( reference_tuple )
-        .combine( SAMTOOLS_FAIDX.out.fai )
+        .combine( reference_index )
         .multiMap { it ->
             nuc_grouped:    tuple( it[0], it[1] )
             reference:      it[-3]

--- a/subworkflows/local/pep_alignments.nf
+++ b/subworkflows/local/pep_alignments.nf
@@ -53,7 +53,7 @@ workflow PEP_ALIGNMENTS {
     //
     MINIPROT_ALIGN.out.gff
         .map { it ->
-            tuple([ id:     it[0].org,
+            tuple([ id:     it[0].org + '_pep',
                     type:   it[0].type
                 ],
                 it[1] )

--- a/workflows/treeval.nf
+++ b/workflows/treeval.nf
@@ -101,6 +101,7 @@ workflow TREEVAL {
     //
     GENE_ALIGNMENT ( GENERATE_GENOME.out.dot_genome,
                      GENERATE_GENOME.out.reference_tuple,
+                     GENERATE_GENOME.out.ref_index,
                      YAML_INPUT.out.assembly_classT,
                      YAML_INPUT.out.align_data_dir,
                      YAML_INPUT.out.align_geneset,


### PR DESCRIPTION
Minor fixes including:
- Removing multiple redundant runs of SAMTOOLS_FAIDX
- By request, naming `.gff` files as `_pep.gff`
- Updating some memory requirements, to reduce the number of 130 errors on average genomes.