### PR TITLE
sanger-tol logo

### DIFF
--- a/lib/NfcoreTemplate.groovy
+++ b/lib/NfcoreTemplate.groovy
@@ -323,6 +323,14 @@ class NfcoreTemplate {
         String.format(
             """\n
             ${dashedLine(monochrome_logs)}
+            ${colors.blue}   _____                               ${colors.green} _______   ${colors.red} _${colors.reset}
+            ${colors.blue}  / ____|                              ${colors.green}|__   __|  ${colors.red}| |${colors.reset}
+            ${colors.blue} | (___   __ _ _ __   __ _  ___ _ __ ${colors.reset} ___ ${colors.green}| |${colors.yellow} ___ ${colors.red}| |${colors.reset}
+            ${colors.blue}  \\___ \\ / _` | '_ \\ / _` |/ _ \\ '__|${colors.reset}|___|${colors.green}| |${colors.yellow}/ _ \\${colors.red}| |${colors.reset}
+            ${colors.blue}  ____) | (_| | | | | (_| |  __/ |        ${colors.green}| |${colors.yellow} (_) ${colors.red}| |____${colors.reset}
+            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|        ${colors.green}|_|${colors.yellow}\\___/${colors.red}|______|${colors.reset}
+            ${colors.blue}                      __/ |${colors.reset}
+            ${colors.blue}                     |___/${colors.reset}
             ${colors.purple}  ${workflow.manifest.name} ${workflow_version}${colors.reset}
             ${dashedLine(monochrome_logs)}
             """.stripIndent()


### PR DESCRIPTION
Hiya,

A minor cosmetic change. In this PR I'm adding the sanger-tol logo we're using in the After-Party pipelines to make it all colourful in the terminal :)

<img width="769" alt="Screenshot 2023-08-09 at 22 25 28" src="https://github.com/sanger-tol/treeval/assets/623458/29c458c4-9997-40ba-9b20-3ea9e80f6461">
