### PR TITLE
Workflow report

### DIFF
--- a/lib/TreeValProject.groovy
+++ b/lib/TreeValProject.groovy
@@ -5,7 +5,7 @@ class TreeValProject {
     // Will be used for graph generation.
     //
 
-    public static void summary(workflow, params, metrics) {
+    public static void summary(workflow, params, metrics, log) {
 
         def input_data = [:]
         input_data['version']           = NfcoreTemplate.version( workflow )
@@ -28,6 +28,7 @@ class TreeValProject {
             }
 
             def output_hf = new File(output_directory, "input_data_${input_data.sample_name}_${input_data.entry}_${params.trace_timestamp}.txt")
+            log.info output_hf.name
             output_hf.write """\
                             ---RUN_DATA---
                             Pipeline_version:   ${input_data.version}

--- a/lib/TreeValProject.groovy
+++ b/lib/TreeValProject.groovy
@@ -5,7 +5,7 @@ class TreeValProject {
     // Will be used for graph generation.
     //
 
-    public static void summary(workflow, params) {
+    public static void summary(workflow, params, metrics) {
 
         def input_data = [:]
         input_data['version']           = NfcoreTemplate.version( workflow )
@@ -17,12 +17,10 @@ class TreeValProject {
         input_data['entry']             = params.entry
 
         input_data['input_yaml']        = params.input
-        input_data['sample_name']       = params.sample_id.value
-        input_data['rf_data']           = params.rf_data.value
-        input_data['pb_data']           = params.pb_data.value
-        input_data['cm_data']           = params.cm_data.value
-
-        if (workflow.success) {
+        input_data['sample_name']       = metrics.sample_id
+        input_data['rf_data']           = metrics.rf_data
+        input_data['pb_data']           = metrics.pb_data
+        input_data['cm_data']           = metrics.cm_data
 
             def output_directory = new File("${params.tracedir}/")
             if (!output_directory.exists()) {
@@ -53,6 +51,5 @@ class TreeValProject {
                                 "${params.tracedir}/pipeline_execution_${params.trace_timestamp}.txt"]
             file_locs.each{ full_file.append( new File( it ).getText() ) }
 
-        }
     }
 }

--- a/workflows/treeval.nf
+++ b/workflows/treeval.nf
@@ -268,7 +268,7 @@ workflow TREEVAL {
         .set { collected_metrics_ch }
 
     collected_metrics_ch.map { metrics ->
-        TreeValProject.summary(workflow, params, metrics)
+        TreeValProject.summary(workflow, params, metrics, log)
     }
 
     emit:

--- a/workflows/treeval.nf
+++ b/workflows/treeval.nf
@@ -248,21 +248,28 @@ workflow TREEVAL {
     GENERATE_GENOME.out.reference_tuple
         .combine( YAML_INPUT.out.assembly_classT )
         .combine( YAML_INPUT.out.assembly_ttype )
-        .map { meta, reference, lineage, ticket ->
-            tuple(
+        .combine( YAML_INPUT.out.assembly_id )
+        .combine( LONGREAD_COVERAGE.out.ch_reporting )
+        .combine( HIC_MAPPING.out.ch_reporting )
+        .map { meta, reference, lineage, ticket, sample_id, longread_meta, longread_files, hic_meta, hic_files -> [
+            rf_data: tuple(
                 [   id: meta.id,
                     sz: file(reference).size(),
                     ln: lineage,
                     tk: ticket  ],
                 reference
-            )
+            ),
+            sample_id: sample_id,
+            pb_data: tuple(longread_meta, longread_files),
+            cm_data: tuple(hic_meta, hic_files),
+            ]
         }
-        .set { rf_data }
+        //.view()
+        .set { collected_metrics_ch }
 
-    params.sample_id    = YAML_INPUT.out.assembly_id.collect()
-    params.rf_data      = rf_data.collect()                              // reference data           tuple( [ id, size, lineage, ticket ], file)
-    params.pb_data      = LONGREAD_COVERAGE.out.ch_reporting.collect()   // merged pacbio.bam data   tuple( [ id, size ], file ) | Should really be a collected list of the raw fasta
-    params.cm_data      = HIC_MAPPING.out.ch_reporting.collect()         // merged cram.bam data     tuple( [ id, size ], file ) | Should really be a collected list of the raw cram
+    collected_metrics_ch.map { metrics ->
+        TreeValProject.summary(workflow, params, metrics)
+    }
 
     emit:
     software_ch     = CUSTOM_DUMPSOFTWAREVERSIONS.out.yml
@@ -284,9 +291,6 @@ workflow.onComplete {
     if (params.hook_url) {
         NfcoreTemplate.IM_notification(workflow, params, summary_params, projectDir, log)
     }
-
-    TreeValProject.summary(workflow, params)
-
 }
 
 /*

--- a/workflows/treeval_rapid.nf
+++ b/workflows/treeval_rapid.nf
@@ -132,41 +132,32 @@ workflow TREEVAL_RAPID {
     GENERATE_GENOME.out.reference_tuple
         .combine( YAML_INPUT.out.assembly_classT )
         .combine( YAML_INPUT.out.assembly_ttype )
-        .map { meta, reference, lineage, ticket ->
-            tuple(
+        .combine( YAML_INPUT.out.assembly_id )
+        .combine( LONGREAD_COVERAGE.out.ch_reporting )
+        .combine( HIC_MAPPING.out.ch_reporting )
+        .map { meta, reference, lineage, ticket, sample_id, longread_meta, longread_files, hic_meta, hic_files -> [
+            rf_data: tuple(
                 [   id: meta.id,
                     sz: file(reference).size(),
                     ln: lineage,
                     tk: ticket  ],
                 reference
-            )
+            ),
+            sample_id: sample_id,
+            pb_data: tuple(longread_meta, longread_files),
+            cm_data: tuple(hic_meta, hic_files),
+            ]
         }
-        .set { rf_data }
+        //.view()
+        .set { collected_metrics_ch }
 
-    params.sample_id    = YAML_INPUT.out.assembly_id.collect()
-    params.rf_data      = rf_data.collect()                              // reference data           tuple( [ id, size, lineage, ticket ], file)
-    params.pb_data      = LONGREAD_COVERAGE.out.ch_reporting.collect()   // merged pacbio.bam data   tuple( [ id, size ], file ) | Should really be a collected list of the raw fasta
-    params.cm_data      = HIC_MAPPING.out.ch_reporting.collect()         // merged cram.bam data     tuple( [ id, size ], file ) | Should really be a collected list of the raw cram
+    collected_metrics_ch.map { metrics ->
+        TreeValProject.summary(workflow, params, metrics)
+    }
 
     emit:
     software_ch     = CUSTOM_DUMPSOFTWAREVERSIONS.out.yml
     versions_ch     = CUSTOM_DUMPSOFTWAREVERSIONS.out.versions
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    COMPLETION EMAIL AND SUMMARY
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-workflow.onComplete {
-    if (params.email || params.email_on_fail) {
-        NfcoreTemplate.email(workflow, params, summary_params, projectDir, log)
-    }
-    NfcoreTemplate.summary(workflow, params, log)
-
-    TreeValProject.summary(workflow, params)
-
 }
 
 /*

--- a/workflows/treeval_rapid.nf
+++ b/workflows/treeval_rapid.nf
@@ -152,7 +152,7 @@ workflow TREEVAL_RAPID {
         .set { collected_metrics_ch }
 
     collected_metrics_ch.map { metrics ->
-        TreeValProject.summary(workflow, params, metrics)
+        TreeValProject.summary(workflow, params, metrics, log)
     }
 
     emit:


### PR DESCRIPTION
Closes #129 

Hi @DLBPointon 

In #132 I couldn't get `workflow.onComplete` to work at all, but even if I could run it, there are problems (cf #129) and the current implementation feels awkward in some regards:

- Values are added to `params` _during_ the workflow, which is not really recommended.
- Values can't be retrieved the normal way - `.value()` needs to be added. Probably a consequence of the above !

Here I present an alternative way of running the summary function, simply through regular channel manipulations and function calls.

1. All the data are collected with `combine()` in a channel.
2. Then structured into a map with `.map`.
3. The resulting channel is called`collected_metrics_ch`. By construction, it contains a single element.
4. `TreeValProject.summary` is called  on that map object, plus the `workflow` and `params`.

cc-ing @priyanka-surana for visibility

<!--
# sanger-tol/treeval pull request

Many thanks for contributing to sanger-tol/treeval!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
