### PR TITLE
Removing extra spaces in config

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -218,7 +218,7 @@ process {
     // GENERAL MODULE LIMITS
     //      Based on reports from SummaryStats
     //      Most of the final conversion modules barely use any resources
-    withName: '( TABIX_BGZIPTABIX | UCSC_BEDTOBIGBED )' {
+    withName: '(TABIX_BGZIPTABIX|UCSC_BEDTOBIGBED)' {
         cpus   = { check_max( 1                         , 'cpus'    ) }
         memory = { check_max( 2.GB      * task.attempt  , 'memory'  ) }
     }


### PR DESCRIPTION
Very small PR.
Removes 4 extra spaces which were stopping the config being parsed properly. This was non-fatal as the pipeline just didn't recognise the process with the extra spaces, which is why it still passed tests.

Closes #181 