### PR TITLE
Adding -S (Buffer size) and -T (temp dir) to mitigate sort error.

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -363,7 +363,7 @@ process {
     }
 
     withName: ".*:.*:KMER_READ_COVERAGE:GNU_SORT" {
-        ext.args        = "-k1,1 -k2,2n"
+        ext.args        = "-k1,1 -k2,2n -S${task.memory.mega - 100}M -T ."
     }
 
     withName: ".*:.*:KMER_READ_COVERAGE:UCSC_BEDGRAPHTOBIGWIG" {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -363,7 +363,7 @@ process {
     }
 
     withName: ".*:.*:KMER_READ_COVERAGE:GNU_SORT" {
-        ext.args        = "-k1,1 -k2,2n -S${task.memory.mega - 100}M -T ."
+        ext.args        = { "-k1,1 -k2,2n -S${task.memory.mega - 100}M -T ." }
     }
 
     withName: ".*:.*:KMER_READ_COVERAGE:UCSC_BEDGRAPHTOBIGWIG" {


### PR DESCRIPTION
Error with KMER coverage in some cases running out of temp storage. Adding flags for temp storage and buffersize.