### PR TITLE
Updates to some modules / pretext updates re-applied / mummer fix

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core==2.10.0
+          pip install nf-core==2.8.0
 
       - name: Run nf-core lint
         env:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core==2.8.0
+          pip install nf-core==2.10.0
 
       - name: Run nf-core lint
         env:

--- a/modules.json
+++ b/modules.json
@@ -8,192 +8,267 @@
                     "bedtools/bamtobed": {
                         "branch": "master",
                         "git_sha": "1d1cb7bfef6cf67fbc7faafa6992ad8bdc3045b3",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/genomecov": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/intersect": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/makewindows": {
                         "branch": "master",
                         "git_sha": "3b248b84694d1939ac4bb33df84bf6233a34d668",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/map": {
                         "branch": "master",
                         "git_sha": "3b248b84694d1939ac4bb33df84bf6233a34d668",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/merge": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/sort": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "busco": {
                         "branch": "master",
                         "git_sha": "e3126f437c336c826f242842fe51769cfce0ec2d",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "81f27e75847087865299cc46605deb3b09b4e0a2",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cooler/cload": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cooler/zoomify": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "8ec825f465b9c17f9d83000022995b4f7de6fe93",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/getchromsizes": {
                         "branch": "master",
                         "git_sha": "1b0ffa4e5aed5b7e3cd4311af31bd3b2c8345051",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/custom/getchromsizes/custom-getchromsizes.diff"
                     },
                     "fastk/fastk": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gnu/sort": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "miniprot/align": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "miniprot/index": {
                         "branch": "master",
                         "git_sha": "8d737766e8f3c1417212b4b56acb959f3c356d26",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "mummer": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/mummer/mummer.diff"
                     },
                     "paftools/sam2paf": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pretextmap": {
                         "branch": "master",
                         "git_sha": "decfb802f2e573efb7b44ff06b11ecf16853054d",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/pretextmap/pretextmap.diff"
                     },
                     "pretextsnapshot": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/pretextsnapshot/pretextsnapshot.diff"
                     },
                     "samtools/faidx": {
                         "branch": "master",
-                        "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/markdup": {
                         "branch": "master",
-                        "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/merge": {
                         "branch": "master",
-                        "git_sha": "0460d316170f75f323111b4a2c0a2989f0c32013",
-                        "installed_by": ["modules"]
+                        "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/sort": {
                         "branch": "master",
-                        "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/view": {
                         "branch": "master",
-                        "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": ["modules"]
+                        "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "seqtk/cutn": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "tabix/bgziptabix": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/tabix/bgziptabix/tabix-bgziptabix.diff"
                     },
                     "ucsc/bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "ucsc/bedtobigbed": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "windowmasker/mkcounts": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "windowmasker/ustat": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },

--- a/modules.json
+++ b/modules.json
@@ -8,267 +8,193 @@
                     "bedtools/bamtobed": {
                         "branch": "master",
                         "git_sha": "1d1cb7bfef6cf67fbc7faafa6992ad8bdc3045b3",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/genomecov": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/intersect": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/makewindows": {
                         "branch": "master",
                         "git_sha": "3b248b84694d1939ac4bb33df84bf6233a34d668",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/map": {
                         "branch": "master",
                         "git_sha": "3b248b84694d1939ac4bb33df84bf6233a34d668",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/merge": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/sort": {
                         "branch": "master",
                         "git_sha": "575e1bc54b083fb15e7dd8b5fcc40bea60e8ce83",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "busco": {
                         "branch": "master",
                         "git_sha": "e3126f437c336c826f242842fe51769cfce0ec2d",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "81f27e75847087865299cc46605deb3b09b4e0a2",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cooler/cload": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cooler/zoomify": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "8ec825f465b9c17f9d83000022995b4f7de6fe93",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/getchromsizes": {
                         "branch": "master",
                         "git_sha": "1b0ffa4e5aed5b7e3cd4311af31bd3b2c8345051",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/custom/getchromsizes/custom-getchromsizes.diff"
                     },
                     "fastk/fastk": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gnu/sort": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "miniprot/align": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "miniprot/index": {
                         "branch": "master",
                         "git_sha": "8d737766e8f3c1417212b4b56acb959f3c356d26",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "mummer": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/mummer/mummer.diff"
                     },
                     "paftools/sam2paf": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pretextmap": {
                         "branch": "master",
                         "git_sha": "decfb802f2e573efb7b44ff06b11ecf16853054d",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/pretextmap/pretextmap.diff"
                     },
                     "pretextsnapshot": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/pretextsnapshot/pretextsnapshot.diff"
                     },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "a64788f5ad388f1d2ac5bd5f1f3f8fc81476148c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/markdup": {
                         "branch": "master",
                         "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/merge": {
                         "branch": "master",
                         "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "ce0b1aed7d504883061e748f492a31bf44c5777c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "seqtk/cutn": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "tabix/bgziptabix": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/tabix/bgziptabix/tabix-bgziptabix.diff"
                     },
                     "ucsc/bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "ucsc/bedtobigbed": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "windowmasker/mkcounts": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "windowmasker/ustat": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             },

--- a/modules/nf-core/mummer/main.nf
+++ b/modules/nf-core/mummer/main.nf
@@ -9,7 +9,7 @@ process MUMMER {
         'biocontainers/mummer:3.23--pl5262h1b792b2_12' }"
 
     input:
-    tuple val(meta), path(ref), path(query)
+    tuple val(meta), path(ref, stageAs: 'ref.fasta'), path(query, stageAs: 'query.fasta') // Staging removes the ability to deal with zipped files here
 
     output:
     tuple val(meta), path("*.coords"), emit: coords

--- a/modules/nf-core/mummer/mummer.diff
+++ b/modules/nf-core/mummer/mummer.diff
@@ -1,0 +1,14 @@
+Changes in module 'nf-core/mummer'
+--- modules/nf-core/mummer/main.nf
++++ modules/nf-core/mummer/main.nf
+@@ -9,7 +9,7 @@
+         'biocontainers/mummer:3.23--pl5262h1b792b2_12' }"
+ 
+     input:
+-    tuple val(meta), path(ref), path(query)
++    tuple val(meta), path(ref, stageAs: 'ref.fasta'), path(query, stageAs: 'query.fasta') // Staging removes the ability to deal with zipped files here
+ 
+     output:
+     tuple val(meta), path("*.coords"), emit: coords
+
+************************************************************

--- a/modules/nf-core/pretextmap/main.nf
+++ b/modules/nf-core/pretextmap/main.nf
@@ -5,8 +5,8 @@ process PRETEXTMAP {
 
     conda "bioconda::pretextmap=0.1.9 bioconda::samtools=1.17"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61%3A44321ab4d64f0b6d0c93abbd1406369d1b3da684-0':
-        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:44321ab4d64f0b6d0c93abbd1406369d1b3da684-0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1' :
+        'biocontainers/samtools:1.18--h50ea8bc_1' }"
 
     input:
     tuple val(meta), path(input)
@@ -20,13 +20,15 @@ process PRETEXTMAP {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    def reference = fasta ? "--reference ${fasta}" : ""
+    def VERSION         = "0.1.9"
+    def args            = task.ext.args ?: ''
+    def prefix          = task.ext.prefix ?: "${meta.id}"
+    def reference       = fasta ? "--reference ${fasta}" : ""
+    def pretext_path    = "${projectDir}/bin/PretextMap/bin/PretextMap"
 
     """
     if [[ $input == *.pairs.gz ]]; then
-        zcat $input | PretextMap \\
+        zcat $input | ${pretext_path} \\
             $args \\
             -o ${prefix}.pretext
     else
@@ -34,26 +36,27 @@ process PRETEXTMAP {
             view \\
             $reference \\
             -h \\
-            $input | PretextMap \\
+            $input | ${pretext_path} \\
             $args \\
             -o ${prefix}.pretext
     fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        pretextmap: \$(PretextMap | grep "Version" | sed 's/PretextMap Version //g')
+        pretextmap: $VERSION
         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' )
     END_VERSIONS
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION         = "0.1.9"
+    def prefix          = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.pretext
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        pretextmap: \$(PretextMap | grep "Version" | sed 's/PretextMap Version //g')
+        pretextmap: $VERSION
         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' ))
     END_VERSIONS
     """

--- a/modules/nf-core/pretextmap/pretextmap.diff
+++ b/modules/nf-core/pretextmap/pretextmap.diff
@@ -1,0 +1,68 @@
+Changes in module 'nf-core/pretextmap'
+--- modules/nf-core/pretextmap/main.nf
++++ modules/nf-core/pretextmap/main.nf
+@@ -5,8 +5,8 @@
+ 
+     conda "bioconda::pretextmap=0.1.9 bioconda::samtools=1.17"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61%3A44321ab4d64f0b6d0c93abbd1406369d1b3da684-0':
+-        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:44321ab4d64f0b6d0c93abbd1406369d1b3da684-0' }"
++        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1' :
++        'biocontainers/samtools:1.18--h50ea8bc_1' }"
+ 
+     input:
+     tuple val(meta), path(input)
+@@ -20,13 +20,15 @@
+     task.ext.when == null || task.ext.when
+ 
+     script:
+-    def args = task.ext.args ?: ''
+-    def prefix = task.ext.prefix ?: "${meta.id}"
+-    def reference = fasta ? "--reference ${fasta}" : ""
++    def VERSION         = "0.1.9"
++    def args            = task.ext.args ?: ''
++    def prefix          = task.ext.prefix ?: "${meta.id}"
++    def reference       = fasta ? "--reference ${fasta}" : ""
++    def pretext_path    = "${projectDir}/bin/PretextMap/bin/PretextMap"
+ 
+     """
+     if [[ $input == *.pairs.gz ]]; then
+-        zcat $input | PretextMap \\
++        zcat $input | ${pretext_path} \\
+             $args \\
+             -o ${prefix}.pretext
+     else
+@@ -34,26 +36,27 @@
+             view \\
+             $reference \\
+             -h \\
+-            $input | PretextMap \\
++            $input | ${pretext_path} \\
+             $args \\
+             -o ${prefix}.pretext
+     fi
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        pretextmap: \$(PretextMap | grep "Version" | sed 's/PretextMap Version //g')
++        pretextmap: $VERSION
+         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' )
+     END_VERSIONS
+     """
+ 
+     stub:
+-    def prefix = task.ext.prefix ?: "${meta.id}"
++    def VERSION         = "0.1.9"
++    def prefix          = task.ext.prefix ?: "${meta.id}"
+     """
+     touch ${prefix}.pretext
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        pretextmap: \$(PretextMap | grep "Version" | sed 's/PretextMap Version //g')
++        pretextmap: $VERSION
+         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' ))
+     END_VERSIONS
+     """
+
+************************************************************

--- a/modules/nf-core/pretextsnapshot/main.nf
+++ b/modules/nf-core/pretextsnapshot/main.nf
@@ -2,11 +2,9 @@ process PRETEXTSNAPSHOT {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::pretextsnapshot=0.0.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pretextsnapshot:0.0.4--h7d875b9_0':
-        'biocontainers/pretextsnapshot:0.0.4--h7d875b9_0' }"
-
+            'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+            'docker.io/ubuntu:20.04' }"
     input:
     tuple val(meta), path(pretext_map)
 
@@ -18,18 +16,32 @@ process PRETEXTSNAPSHOT {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION         = "0.0.4"
+    def args            = task.ext.args ?: ''
+    def prefix          = task.ext.prefix ?: "${meta.id}"
+    def pretext_path    = "${projectDir}/bin/PretextSnapshot/bin/PretextSnapshot"
     """
-    PretextSnapshot \\
+    ${pretext_path} \\
         $args \\
+        --memory $task.memory \\
         --map $pretext_map \\
         --prefix $prefix \\
         --folder .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        pretextsnapshot: \$(echo \$(PretextSnapshot --version 2>&1) | sed 's/^.*PretextSnapshot Version //' )
+        pretextsnapshot: $VERSION
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.png
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pretextsnapshot: $VERSION
     END_VERSIONS
     """
 }

--- a/modules/nf-core/pretextsnapshot/pretextsnapshot.diff
+++ b/modules/nf-core/pretextsnapshot/pretextsnapshot.diff
@@ -1,0 +1,56 @@
+Changes in module 'nf-core/pretextsnapshot'
+--- modules/nf-core/pretextsnapshot/main.nf
++++ modules/nf-core/pretextsnapshot/main.nf
+@@ -2,11 +2,9 @@
+     tag "$meta.id"
+     label 'process_single'
+ 
+-    conda "bioconda::pretextsnapshot=0.0.4"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/pretextsnapshot:0.0.4--h7d875b9_0':
+-        'biocontainers/pretextsnapshot:0.0.4--h7d875b9_0' }"
+-
++            'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
++            'docker.io/ubuntu:20.04' }"
+     input:
+     tuple val(meta), path(pretext_map)
+ 
+@@ -18,18 +16,32 @@
+     task.ext.when == null || task.ext.when
+ 
+     script:
+-    def args = task.ext.args ?: ''
+-    def prefix = task.ext.prefix ?: "${meta.id}"
++    def VERSION         = "0.0.4"
++    def args            = task.ext.args ?: ''
++    def prefix          = task.ext.prefix ?: "${meta.id}"
++    def pretext_path    = "${projectDir}/bin/PretextSnapshot/bin/PretextSnapshot"
+     """
+-    PretextSnapshot \\
++    ${pretext_path} \\
+         $args \\
++        --memory $task.memory \\
+         --map $pretext_map \\
+         --prefix $prefix \\
+         --folder .
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        pretextsnapshot: \$(echo \$(PretextSnapshot --version 2>&1) | sed 's/^.*PretextSnapshot Version //' )
++        pretextsnapshot: $VERSION
++    END_VERSIONS
++    """
++
++    stub:
++    def prefix = task.ext.prefix ?: "${meta.id}"
++    """
++    touch ${prefix}.png
++
++    cat <<-END_VERSIONS > versions.yml
++    "${task.process}":
++        pretextsnapshot: $VERSION
+     END_VERSIONS
+     """
+ }
+
+************************************************************

--- a/modules/nf-core/samtools/markdup/environment.yml
+++ b/modules/nf-core/samtools/markdup/environment.yml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::samtools=1.18
+  - bioconda::htslib=1.18

--- a/modules/nf-core/samtools/merge/environment.yml
+++ b/modules/nf-core/samtools/merge/environment.yml
@@ -1,4 +1,4 @@
-name: samtools_faidx
+name: samtools_merge
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/samtools/merge/main.nf
+++ b/modules/nf-core/samtools/merge/main.nf
@@ -2,10 +2,10 @@ process SAMTOOLS_MERGE {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1' :
+        'biocontainers/samtools:1.18--h50ea8bc_1' }"
 
     input:
     tuple val(meta), path(input_files, stageAs: "?/*")
@@ -16,6 +16,7 @@ process SAMTOOLS_MERGE {
     tuple val(meta), path("${prefix}.bam") , optional:true, emit: bam
     tuple val(meta), path("${prefix}.cram"), optional:true, emit: cram
     tuple val(meta), path("*.csi")         , optional:true, emit: csi
+    tuple val(meta), path("*.crai")        , optional:true, emit: crai
     path  "versions.yml"                                  , emit: versions
 
 
@@ -43,10 +44,14 @@ process SAMTOOLS_MERGE {
     """
 
     stub:
+    def args = task.ext.args   ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
     def file_type = input_files instanceof List ? input_files[0].getExtension() : input_files.getExtension()
+    def index_type = file_type == "bam" ? "csi" : "crai"
+    def index = args.contains("--write-index") ? "touch ${prefix}.${index_type}" : ""
     """
     touch ${prefix}.${file_type}
+    ${index}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/samtools/merge/meta.yml
+++ b/modules/nf-core/samtools/merge/meta.yml
@@ -65,7 +65,17 @@ output:
       type: file
       description: BAM index file (optional)
       pattern: "*.csi"
+  - crai:
+      type: file
+      description: CRAM index file (optional)
+      pattern: "*.crai"
 authors:
+  - "@drpatelh"
+  - "@yuukiiwa "
+  - "@maxulysse"
+  - "@FriederikeHanssen"
+  - "@ramprasadn"
+maintainers:
   - "@drpatelh"
   - "@yuukiiwa "
   - "@maxulysse"

--- a/modules/nf-core/samtools/merge/tests/index.config
+++ b/modules/nf-core/samtools/merge/tests/index.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = "--write-index"
+}

--- a/modules/nf-core/samtools/merge/tests/main.nf.test
+++ b/modules/nf-core/samtools/merge/tests/main.nf.test
@@ -1,0 +1,156 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_MERGE"
+    script "../main.nf"
+    process "SAMTOOLS_MERGE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/merge"
+
+    test("sarscov2 - [bam1, bam2, bam3], [], []") {
+
+        config "./index.config"
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                    [ id: 'test' ], // meta map
+                    [
+                        file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam'], checkIfExists: true),
+                        file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
+                        file(params.test_data['sarscov2']['illumina']['test_single_end_sorted_bam'], checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.cram,
+                    file(process.out.csi[0][1]).name,
+                    process.out.crai,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - [cram1, cram2], fasta, fai") {
+
+        config "./index.config"
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                    [ id: 'test' ], // meta map
+                    [
+                        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_recalibrated_sorted_cram'], checkIfExists: true),
+                        file(params.test_data['homo_sapiens']['illumina']['test2_paired_end_recalibrated_sorted_cram'], checkIfExists: true),
+                    ]
+                ]
+                input[1] = [ 
+                    [id:'genome'],
+                    file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                input[2] = [
+                    [id:'genome'],
+                    file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.cram[0][1]).name,
+                    process.out.bam,
+                    file(process.out.crai[0][1]).name,
+                    process.out.csi,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - bam, [], []") {
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                    [ id: 'test' ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam'], checkIfExists: true),
+                ]
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.cram,
+                    process.out.crai,
+                    process.out.csi,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - [bam1, bam2, bam3], [], [] - stub") {
+
+        config "./index.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                    [ id: 'test' ], // meta map
+                    [
+                        file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam'], checkIfExists: true),
+                        file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
+                        file(params.test_data['sarscov2']['illumina']['test_single_end_sorted_bam'], checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bam[0][1]).name,
+                    process.out.cram,
+                    file(process.out.csi[0][1]).name,
+                    process.out.crai,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/samtools/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/merge/tests/main.nf.test.snap
@@ -1,0 +1,68 @@
+{
+    "sarscov2 - bam, [], []": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,71986103374bdddb2e3093d20e7d06cb"
+            ]
+        ],
+        "timestamp": "2023-12-04T17:13:30.244841621"
+    },
+    "sarscov2 - [bam1, bam2, bam3], [], [] - stub": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            "test.csi",
+            [
+                
+            ],
+            [
+                "versions.yml:md5,71986103374bdddb2e3093d20e7d06cb"
+            ]
+        ],
+        "timestamp": "2023-12-04T17:10:14.861445721"
+    },
+    "homo_sapiens - [cram1, cram2], fasta, fai": {
+        "content": [
+            "test.cram",
+            [
+                
+            ],
+            "test.cram.crai",
+            [
+                
+            ],
+            [
+                "versions.yml:md5,71986103374bdddb2e3093d20e7d06cb"
+            ]
+        ],
+        "timestamp": "2023-12-04T17:09:29.716002618"
+    },
+    "sarscov2 - [bam1, bam2, bam3], [], []": {
+        "content": [
+            "test.bam",
+            [
+                
+            ],
+            "test.bam.csi",
+            [
+                
+            ],
+            [
+                "versions.yml:md5,71986103374bdddb2e3093d20e7d06cb"
+            ]
+        ],
+        "timestamp": "2023-12-04T17:08:42.329973045"
+    }
+}

--- a/modules/nf-core/samtools/merge/tests/tags.yml
+++ b/modules/nf-core/samtools/merge/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/merge:
+  - "modules/nf-core/samtools/merge/**"

--- a/modules/nf-core/samtools/sort/environment.yml
+++ b/modules/nf-core/samtools/sort/environment.yml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::samtools=1.18
+  - bioconda::htslib=1.18

--- a/modules/nf-core/samtools/view/environment.yml
+++ b/modules/nf-core/samtools/view/environment.yml
@@ -5,3 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::samtools=1.18
+  - bioconda::htslib=1.18

--- a/modules/nf-core/tabix/bgziptabix/main.nf
+++ b/modules/nf-core/tabix/bgziptabix/main.nf
@@ -19,9 +19,9 @@ process TABIX_BGZIPTABIX {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args    = task.ext.args ?: ''
+    def args2   = meta.max_scaff == 'csi' ? "--csi" : ''
+    def prefix  = task.ext.prefix ?: "${meta.id}"
     """
     bgzip  --threads ${task.cpus} -c $args $input > ${prefix}.${input.getExtension()}.gz
     tabix $args2 ${prefix}.${input.getExtension()}.gz

--- a/modules/nf-core/tabix/bgziptabix/tabix-bgziptabix.diff
+++ b/modules/nf-core/tabix/bgziptabix/tabix-bgziptabix.diff
@@ -1,0 +1,18 @@
+Changes in module 'nf-core/tabix/bgziptabix'
+--- modules/nf-core/tabix/bgziptabix/main.nf
++++ modules/nf-core/tabix/bgziptabix/main.nf
+@@ -19,9 +19,9 @@
+     task.ext.when == null || task.ext.when
+ 
+     script:
+-    def args = task.ext.args ?: ''
+-    def args2 = task.ext.args2 ?: ''
+-    def prefix = task.ext.prefix ?: "${meta.id}"
++    def args    = task.ext.args ?: ''
++    def args2   = meta.max_scaff == 'csi' ? "--csi" : ''
++    def prefix  = task.ext.prefix ?: "${meta.id}"
+     """
+     bgzip  --threads ${task.cpus} -c $args $input > ${prefix}.${input.getExtension()}.gz
+     tabix $args2 ${prefix}.${input.getExtension()}.gz
+
+************************************************************


### PR DESCRIPTION
Some modules escaped the 'great update'. Samtools, ucsc, windowmasker.

Mummer fix to add stageAs to both ref and query in order to avoid name conflicts.

The updates for pretext apparently reverted. So they have been re-applied in this PR.

PR -> galaxy due to conflicts in hic_opt