### PR TITLE
Dp24 only csi

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -170,7 +170,8 @@ process {
 
     withName: ".*:.*:GAP_FINDER:TABIX_BGZIPTABIX" {
         ext.prefix      = { "gap_${meta.id}" }
-        ext.args2        = { "${meta.max_scaff >= 500000000 ? "--csi" : "" }" }
+        ext.args        = ""
+        ext.args2       = { "--csi" }
     }
 
 
@@ -196,7 +197,7 @@ process {
 
     withName: ".*:.*:.*:PEP_ALIGNMENTS:TABIX_BGZIPTABIX" {
         ext.prefix      = { "pep_${meta.id}" }
-        ext.args2        = { "${meta.max_scaff >= 500000000 ? "--csi" : "" }" }
+        ext.args2       = { "--csi" }
     }
 
     //
@@ -293,7 +294,7 @@ process {
 
     withName: ".*:.*:TELO_FINDER:TABIX_BGZIPTABIX" {
         ext.prefix      = { "telo_${meta.id}" }
-        ext.args2       = { "${meta.max_scaff >= 500000000 ? "--csi" : "" }" }
+        ext.args2       = { "--csi" }
 
     }
 

--- a/subworkflows/local/gap_finder.nf
+++ b/subworkflows/local/gap_finder.nf
@@ -10,7 +10,6 @@ include { TABIX_BGZIPTABIX  } from '../../modules/nf-core/tabix/bgziptabix/main'
 workflow GAP_FINDER {
     take:
     reference_tuple     // Channel: tuple [ val(meta), path(fasta) ]
-    max_scaff_size      // Channel: val(size of largest scaffold in bp)
 
     main:
     ch_versions     = Channel.empty()
@@ -32,23 +31,10 @@ workflow GAP_FINDER {
     ch_versions     = ch_versions.mix( GAP_LENGTH.out.versions )
 
     //
-    // LOGIC: Adding the largest scaffold size to the meta data so it can be used in the modules.config
-    //
-    SEQTK_CUTN.out.bed
-        .combine(max_scaff_size)
-        .map {meta, row, scaff ->
-            tuple([ id          : meta.id,
-                    max_scaff   : scaff
-                ],
-                file(row)
-            )}
-        .set { modified_bed_ch }
-
-    //
     // MODULE: BGZIP AND TABIX THE GAP FILE
     //
     TABIX_BGZIPTABIX (
-        modified_bed_ch
+        SEQTK_CUTN.out.bed
     )
     ch_versions     = ch_versions.mix( TABIX_BGZIPTABIX.out.versions )
 

--- a/subworkflows/local/gene_alignment.nf
+++ b/subworkflows/local/gene_alignment.nf
@@ -18,7 +18,6 @@ workflow GENE_ALIGNMENT {
     dot_genome          // Channel: [ val(meta), path(file) ]
     reference_tuple     // Channel: [ val(meta), path(file) ]
     reference_index     // Channel: [ val(meta), path(file) ]
-    max_scaff_size      // Channel: val(size of largest scaffold in bp)
     alignment_datadir   // Channel: val(geneset_dir)
     alignment_genesets  // Channel: val(geneset_id)
     alignment_common    // Channel: val(common_name) // Not yet in use
@@ -83,7 +82,6 @@ workflow GENE_ALIGNMENT {
     //
     PEP_ALIGNMENTS (    reference_tuple,
                         pep_files,
-                        max_scaff_size
     )
     ch_versions = ch_versions.mix(PEP_ALIGNMENTS.out.versions)
 

--- a/subworkflows/local/pep_alignments.nf
+++ b/subworkflows/local/pep_alignments.nf
@@ -14,7 +14,6 @@ workflow PEP_ALIGNMENTS {
     take:
     reference_tuple     // Channel: tuple [ val(meta), path(file) ]
     pep_files           // Channel: tuple [ val(meta), path(file) ]
-    max_scaff_size      // Channel: tuple val(size of largest scaffold in bp)
 
     main:
     ch_versions         = Channel.empty()
@@ -109,23 +108,12 @@ workflow PEP_ALIGNMENTS {
     )
     ch_versions         = ch_versions.mix( EXTRACT_COV_IDEN.out.versions )
 
-    BEDTOOLS_SORT.out.sorted
-        .combine( max_scaff_size )
-        .map {meta, row, scaff ->
-            tuple(
-                [   id          : meta.id,
-                    max_scaff   : scaff >= 500000000 ? 'csi': '' ],
-                file( row )
-            )
-        }
-        .set { modified_bed_ch }
-
     //
     // MODULE: COMPRESS AND INDEX MERGED.GFF
     //         EMITS A TBI FILE
     //
     TABIX_BGZIPTABIX (
-        modified_bed_ch
+        BEDTOOLS_SORT.out.sorted
     )
     ch_versions         = ch_versions.mix( TABIX_BGZIPTABIX.out.versions )
 

--- a/subworkflows/local/telo_finder.nf
+++ b/subworkflows/local/telo_finder.nf
@@ -11,7 +11,6 @@ include { TABIX_BGZIPTABIX          } from '../../modules/nf-core/tabix/bgziptab
 workflow TELO_FINDER {
 
     take:
-    max_scaff_size      // Channel: val(size of largest scaffold in bp)
     reference_tuple     // Channel: tuple [ val(meta), path(fasta) ]
     teloseq
 
@@ -44,24 +43,10 @@ workflow TELO_FINDER {
     ch_versions     = ch_versions.mix( EXTRACT_TELO.out.versions )
 
     //
-    // LOGIC: Adding the largest scaffold size to the meta data so it can be used in the modules.config
-    //
-    EXTRACT_TELO.out.bed
-        .combine(max_scaff_size)
-        .map {meta, row, scaff ->
-            tuple(
-                [   id          : meta.id,
-                    max_scaff   : scaff     ],
-                file( row )
-            )
-        }
-        .set { modified_bed_ch }
-
-    //
     // MODULE: BGZIP AND TABIX THE OUTPUT FILE
     //
     TABIX_BGZIPTABIX (
-        modified_bed_ch
+        EXTRACT_TELO.out.bed
     )
     ch_versions     = ch_versions.mix( TABIX_BGZIPTABIX.out.versions )
 

--- a/workflows/treeval.nf
+++ b/workflows/treeval.nf
@@ -139,7 +139,6 @@ workflow TREEVAL {
         GENERATE_GENOME.out.dot_genome,
         YAML_INPUT.out.reference_ch,
         GENERATE_GENOME.out.ref_index,
-        GENERATE_GENOME.out.max_scaff_size,
         YAML_INPUT.out.align_data_dir,
         YAML_INPUT.out.align_geneset,
         YAML_INPUT.out.align_common,
@@ -162,7 +161,6 @@ workflow TREEVAL {
     //
     GAP_FINDER (
         YAML_INPUT.out.reference_ch,
-        GENERATE_GENOME.out.max_scaff_size
     )
     ch_versions     = ch_versions.mix( GAP_FINDER.out.versions )
 
@@ -202,8 +200,7 @@ workflow TREEVAL {
     //
     // SUBWORKFLOW: GENERATE TELOMERE WINDOW FILES WITH PACBIO READS AND REFERENCE
     //
-    TELO_FINDER (   GENERATE_GENOME.out.max_scaff_size,
-                    YAML_INPUT.out.reference_ch,
+    TELO_FINDER (   YAML_INPUT.out.reference_ch,
                     YAML_INPUT.out.teloseq
     )
     ch_versions     = ch_versions.mix( TELO_FINDER.out.versions )


### PR DESCRIPTION
Make csi the one and only index to be produced by the tabix module. This simplifies the modules.config and removed 4*14 lines of code from subworkflows.