### PR TITLE
Add handling of output_bam param

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -41,7 +41,7 @@ process {
 
     // Files to be used for pretext, likely to be deleted once the hic workflow is complete.
     // .bed, .hr.pretext, .lr.pretext, needs centromere
-    withName: 'REFORMAT_INTERSECT|SEQTK_CUTN|GAP_LENGTH|PRETEXT_INGEST_HIRES|PRETEXT_INGEST_SNDRD|COOLER_ZOOMIFY|COV_FOLDER|UCSC_BEDGRAPHTOBIGWIG|BED2BW_NORMAL|BED2BW_AVGCOV|EXTRACT_TELO|JUICER_TOOLS_PRE|SNAPSHOT_SRES|PRETEXT_GRAPH' {
+    withName: 'REFORMAT_INTERSECT|SEQTK_CUTN|GAP_LENGTH|PRETEXT_INGEST_HIRES|PRETEXT_INGEST_SNDRD|COOLER_ZOOMIFY|COV_FOLDER|UCSC_BEDGRAPHTOBIGWIG|BED2BW_NORMAL|BED2BW_AVGCOV|EXTRACT_TELO|JUICER_TOOLS_PRE|SNAPSHOT_SRES|PRETEXT_GRAPH|SAMTOOLS_MERGE_OUTPUT_BAM' {
         publishDir = [
             path: { "${params.outdir}/hic_files" },
             mode: params.publish_dir_mode,
@@ -366,6 +366,10 @@ process {
         ext.prefix      = { "${meta.id}_hic_bwamem2_merge" }
     }
 
+    withName: ".*:.*:HIC_BWAMEM2:SAMTOOLS_MERGE_OUTPUT_BAM" {
+        ext.prefix      = { "${meta.id}_hic_bwamem2_merge" }
+    }
+
     withName: ".*:.*:HIC_MINIMAP2:CRAM_FILTER_MINIMAP2_FILTER5END_FIXMATE_SORT" {
         ext.args        = ""
         ext.args1       = ""
@@ -375,6 +379,10 @@ process {
     }
 
     withName: ".*:.*:HIC_MINIMAP2:SAMTOOLS_MERGE" {
+        ext.prefix      = { "${meta.id}_hic_minimap2_merge" }
+    }
+
+    withName: ".*:.*:HIC_MINIMAP2:SAMTOOLS_MERGE_OUTPUT_BAM" {
         ext.prefix      = { "${meta.id}_hic_minimap2_merge" }
     }
 

--- a/subworkflows/local/hic_mapping.nf
+++ b/subworkflows/local/hic_mapping.nf
@@ -35,6 +35,7 @@ workflow HIC_MAPPING {
     avgcoverage_file    // Channel: tuple [ val(meta), path( file )      ]
     telo_file           // Channel: tuple [ val(meta), path( file )      ]
     repeat_density_file // Channel: tuple [ val(meta), path( file )      ]
+    output_bam          // Channel: val
     workflow_setting    // Channel: val( { RAPID | FULL | RAPID_TOL } )
 
     main:
@@ -90,7 +91,8 @@ workflow HIC_MAPPING {
     HIC_MINIMAP2 (
         ch_aligner.minimap2,
         GENERATE_CRAM_CSV.out.csv,
-        reference_index
+        reference_index,
+        output_bam
     )
     ch_versions         = ch_versions.mix( HIC_MINIMAP2.out.versions )
     mergedbam           = HIC_MINIMAP2.out.mergedbam
@@ -101,7 +103,8 @@ workflow HIC_MAPPING {
     HIC_BWAMEM2 (
         ch_aligner.bwamem2,
         GENERATE_CRAM_CSV.out.csv,
-        reference_index
+        reference_index,
+        output_bam
     )
     ch_versions         = ch_versions.mix( HIC_BWAMEM2.out.versions )
     mergedbam           = mergedbam.mix(HIC_BWAMEM2.out.mergedbam)

--- a/subworkflows/local/yaml_input.nf
+++ b/subworkflows/local/yaml_input.nf
@@ -36,6 +36,7 @@ workflow YAML_INPUT {
                 busco_gene:             ( data.busco )
                 teloseq:                ( data.telomere )
                 map_order:              ( data.map_order)
+                output_bam:             ( data.output_bam)
         }
         .set{ group }
 
@@ -217,6 +218,7 @@ workflow YAML_INPUT {
     assembly_id                      = tolid_version
     reference_ch                     = ref_ch
     map_order_ch                     = group.map_order
+    output_bam_ch                    = group.output_bam
 
     read_ch                          = read_ch
 

--- a/workflows/treeval.nf
+++ b/workflows/treeval.nf
@@ -241,6 +241,7 @@ workflow TREEVAL {
         READ_COVERAGE.out.ch_covbw_avg,
         TELO_FINDER.out.bedgraph_file,
         REPEAT_DENSITY.out.repeat_density,
+        YAML_INPUT.out.output_bam_ch,
         params.entry
     )
     ch_versions     = ch_versions.mix( HIC_MAPPING.out.versions )

--- a/workflows/treeval_rapid.nf
+++ b/workflows/treeval_rapid.nf
@@ -121,6 +121,7 @@ workflow TREEVAL_RAPID {
         READ_COVERAGE.out.ch_covbw_avg,
         TELO_FINDER.out.bedgraph_file,
         REPEAT_DENSITY.out.repeat_density,
+        YAML_INPUT.out.output_bam_ch,
         params.entry
     )
     ch_versions     = ch_versions.mix( HIC_MAPPING.out.versions )

--- a/workflows/treeval_rapid_tol.nf
+++ b/workflows/treeval_rapid_tol.nf
@@ -130,6 +130,7 @@ workflow TREEVAL_RAPID_TOL {
         READ_COVERAGE.out.ch_covbw_avg,
         TELO_FINDER.out.bedgraph_file,
         REPEAT_DENSITY.out.repeat_density,
+        YAML_INPUT.out.output_bam_ch,
         params.entry
     )
     ch_versions     = ch_versions.mix( HIC_MAPPING.out.versions )


### PR DESCRIPTION
<!--
# sanger-tol/treeval pull request

Many thanks for contributing to sanger-tol/treeval!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Added handling of additional parameter in .yaml 'output_bam'. This will have the value 'true' or 'false'. If true, the merged bam will be output to hic_files directory.

