### PR TITLE
Fix off-by-one in chunk ranges

### DIFF
--- a/bin/generate_cram_csv.sh
+++ b/bin/generate_cram_csv.sh
@@ -43,7 +43,7 @@ process_cram_file() {
     local cram=$1
     local chunkn=$2
     local outcsv=$3
-    local $chunksize=$4
+    local chunksize=$4
 
     local read_groups=$(samtools view -H "$cram" | grep '@RG' | awk '{for(i=1;i<=NF;i++){if($i ~ /^ID:/){print substr($i,4)}}}')
     local num_read_groups=$(echo "$read_groups" | wc -w)

--- a/bin/generate_cram_csv.sh
+++ b/bin/generate_cram_csv.sh
@@ -25,7 +25,7 @@ chunk_cram() {
     while [ $to -lt $ncontainers ]; do
         echo "${realcram},${realcrai},${from},${to},${base},${chunkn},${rgline}" >> $outcsv
         from=$((to + 1))
-        ((to += $chunksize))
+        to=$((to + chunksize))
         ((chunkn++))
     done
 
@@ -74,10 +74,16 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+if [ -z "$3" ]; then
+    chunksize=10000
+else
+    chunksize=$3
+fi
+
 cram_path=$1
 chunkn=0
 outcsv=$2
-chunksize=10000
+
 # Loop through each CRAM file in the specified directory. cram cannot be the synlinked cram
 for cram in ${cram_path}/*.cram; do
     realcram=$(readlink -f $cram)

--- a/bin/generate_cram_csv.sh
+++ b/bin/generate_cram_csv.sh
@@ -21,7 +21,6 @@ chunk_cram() {
     local from=0
     local to=$((chunksize - 1))
 
-    
     while [ $to -lt $ncontainers ]; do
         echo "${realcram},${realcrai},${from},${to},${base},${chunkn},${rgline}" >> $outcsv
         from=$((to + 1))


### PR DESCRIPTION
The first chunk had 1 extra container, and the last chunk could have an end coordinate that was invalid (although cram_filter would handle it)

I also make chunk size an optional argument

<!--
# sanger-tol/treeval pull request

Many thanks for contributing to sanger-tol/treeval!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
