### PR TITLE
Softmasked telo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ Our 6th release for sanger-tol/treeval, a hotfix .
 - Updated resources for larger assemblies to avoid hugemem and teramem queues at sanger.
 - Update PRETEXT_INGESTION to use PRETEXT_GRAPH instead.
 - Update SELFCOMP subworkflow to not require motif_len to be specified.
-- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified, otherwise this may have "you screwed up" (legacy internal error message will be changed to something more professional) errors which will break processing in FIND_TELOMERE_WINDOWS.
+- Add GAWK_UPPER_SEQUENCE to force the assembly into uppercase to make telo_finding easier.
+- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified / or telomotif not found in sequence, otherwise this may have "you screwed up" (legacy internal error message will be changed to something more professional) errors which will break processing in FIND_TELOMERE_WINDOWS.
 
 ### Software dependencies
 
-| Module                  | Old Version | New Versions |
-| ----------------------- | ----------- | ------------ |
-| GAWK as GAWK_CLEAN_TELO | -           | 5.3.0        |
+| Module                      | Old Version | New Versions |
+| --------------------------- | ----------- | ------------ |
+| GAWK as GAWK_UPPER_SEQUENCE | -           | 5.3.0        |
+| GAWK as GAWK_CLEAN_TELO     | -           | 5.3.0        |
 
 ## [1.2.2] - Ancient Destiny (H2)- [2025-01-30]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ Our 6th release for sanger-tol/treeval, a hotfix .
 - Updated resources for larger assemblies to avoid hugemem and teramem queues at sanger.
 - Update PRETEXT_INGESTION to use PRETEXT_GRAPH instead.
 - Update SELFCOMP subworkflow to not require motif_len to be specified.
-- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified, otherwise this may have "you screwed up" errors which will break processing in FIND_TELOMERE_WINDOWS
+- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified, otherwise this may have "you screwed up" errors which will break processing in FIND_TELOMERE_WINDOWS.
 
 ### Software dependencies
 
-| Module                | Old Version     | New Versions    |
-| --------------------- | --------------- | --------------- |
-| GAWK as GAWK_CLEAN_TELO | - | 0.0.8-c1 + 1.17 |
+| Module                  | Old Version | New Versions |
+| ----------------------- | ----------- | ------------ |
+| GAWK as GAWK_CLEAN_TELO | -           | 5.3.0        |
 
 ## [1.2.2] - Ancient Destiny (H2)- [2025-01-30]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - Ancient Destiny (H3)- [2025-02-05]
+
+Our 6th release for sanger-tol/treeval, a hotfix .
+
+### Enhancements & Fixes
+
+- Updated resources for larger assemblies to avoid hugemem and teramem queues at sanger.
+- Update PRETEXT_INGESTION to use PRETEXT_GRAPH instead.
+- Update SELFCOMP subworkflow to not require motif_len to be specified.
+- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified, otherwise this may have "you screwed up" errors which will break processing in FIND_TELOMERE_WINDOWS
+
+### Software dependencies
+
+| Module                | Old Version     | New Versions    |
+| --------------------- | --------------- | --------------- |
+| GAWK as GAWK_CLEAN_TELO | - | 0.0.8-c1 + 1.17 |
+
 ## [1.2.2] - Ancient Destiny (H2)- [2025-01-30]
 
 Our 5th release for sanger-tol/treeval, correcting a software bug inside PretextGraph.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Our 6th release for sanger-tol/treeval, a hotfix .
 - Updated resources for larger assemblies to avoid hugemem and teramem queues at sanger.
 - Update PRETEXT_INGESTION to use PRETEXT_GRAPH instead.
 - Update SELFCOMP subworkflow to not require motif_len to be specified.
-- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified, otherwise this may have "you screwed up" errors which will break processing in FIND_TELOMERE_WINDOWS.
+- Add GAWK_CLEAN_TELO to clean the telomere file when lowercase motif is specified, otherwise this may have "you screwed up" (legacy internal error message will be changed to something more professional) errors which will break processing in FIND_TELOMERE_WINDOWS.
 
 ### Software dependencies
 

--- a/assets/local_testing/nxOscDF5033.yaml
+++ b/assets/local_testing/nxOscDF5033.yaml
@@ -10,7 +10,6 @@ map_order: length
 assem_reads:
   read_type: hifi
   read_data: /lustre/scratch123/tol/resources/treeval/treeval-testdata/TreeValSmallData/Oscheius_DF5033/genomic_data/nxOscSpes1/pacbio/fasta/
-  supplementary_data: path
 hic_data:
   hic_cram: /lustre/scratch123/tol/resources/treeval/treeval-testdata/TreeValSmallData/Oscheius_DF5033/genomic_data/nxOscSpes1/hic-arima2/full/
   hic_aligner: minimap2

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -72,16 +72,16 @@ process {
     //
     // NOTE: GAWK module derivatives - More to come
     //
+    withName: 'GAWK_UPPER_SEQUENCE' {
+        ext.args2 = "'/^>/ {print; next} {print toupper($0)}'"  // Convert sequence to uppercase on lines starting with '>'
+        ext.prefix = { "${meta.id}_UPPERCASED" }
+        ext.suffix = 'fasta'
+    }
+
     withName: 'GAWK_CLEAN_TELOMERE' {
         ext.args2 = "'/^>/'"        // Keep lines starting with '>'
         ext.prefix = { "${meta.id}_CLEANED" }
         ext.suffix = 'telomere'     // Must end with telomere otherwise FIND_TELOMERE_WINDOWS will crash
-    }
-
-    withName: 'GAWK_UPPER_SEQUENCE' {
-        ext.args2 = "'/^>/ {print; next} {print toupper($0)}'"  // Convert sequence to uppercase
-        ext.prefix = { "${meta.id}_UPPERCASED" }
-        ext.suffix = 'fasta'
     }
 
     //

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -70,6 +70,15 @@ process {
     //
 
     //
+    // NOTE: GAWK module derivatives - More to come
+    //
+    withName: 'GAWK_CLEAN_TELOMERE' {
+        ext.args2 = "'/^>/'"        // Keep lines starting with '>'
+        ext.prefix = 'telomere'
+        ext.suffix = 'telomere'     // Must end with .telomere otherwise FIND_TELOMERE_WINDOWS will crash
+    }
+
+    //
     // SUBWORKFLOW: MULTIPLE SUBWORKFLOWS
     //
     withName: BEDTOOLS_SORT {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -74,8 +74,14 @@ process {
     //
     withName: 'GAWK_CLEAN_TELOMERE' {
         ext.args2 = "'/^>/'"        // Keep lines starting with '>'
-        ext.prefix = 'telomere'
-        ext.suffix = 'telomere'     // Must end with .telomere otherwise FIND_TELOMERE_WINDOWS will crash
+        ext.prefix = { "${meta.id}_CLEANED" }
+        ext.suffix = 'telomere'     // Must end with telomere otherwise FIND_TELOMERE_WINDOWS will crash
+    }
+
+    withName: 'GAWK_UPPER_SEQUENCE' {
+        ext.args2 = "'/^>/ {print; next} {print toupper($0)}'"  // Convert sequence to uppercase
+        ext.prefix = { "${meta.id}_UPPERCASED" }
+        ext.suffix = 'fasta'
     }
 
     //

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -73,7 +73,7 @@ process {
     // NOTE: GAWK module derivatives - More to come
     //
     withName: 'GAWK_UPPER_SEQUENCE' {
-        ext.args2 = "'/^>/ {print; next} {print toupper($0)}'"  // Convert sequence to uppercase on lines starting with '>'
+        ext.args2 = "'/^>/ {print; next} {print toupper(\$0)}'"  // Convert sequence to uppercase on lines starting with '>'
         ext.prefix = { "${meta.id}_UPPERCASED" }
         ext.suffix = 'fasta'
     }

--- a/modules.json
+++ b/modules.json
@@ -86,7 +86,8 @@
                     "gawk": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/gawk/gawk.diff"
                     },
                     "gnu/sort": {
                         "branch": "master",

--- a/modules.json
+++ b/modules.json
@@ -83,6 +83,11 @@
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/fastk/fastk/fastk-fastk.diff"
                     },
+                    "gawk": {
+                        "branch": "master",
+                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "installed_by": ["modules"]
+                    },
                     "gnu/sort": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",

--- a/modules/nf-core/gawk/environment.yml
+++ b/modules/nf-core/gawk/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::gawk=5.3.0

--- a/modules/nf-core/gawk/gawk.diff
+++ b/modules/nf-core/gawk/gawk.diff
@@ -1,0 +1,20 @@
+Changes in component 'nf-core/gawk'
+'modules/nf-core/gawk/meta.yml' is unchanged
+Changes in 'gawk/main.nf':
+--- modules/nf-core/gawk/main.nf
++++ modules/nf-core/gawk/main.nf
+@@ -8,7 +8,7 @@
+         'biocontainers/gawk:5.3.0' }"
+ 
+     input:
+-    tuple val(meta), path(input, arity: '0..*')
++    tuple val(meta), path(input)
+     path(program_file)
+     val(disable_redirect_output)
+ 
+
+'modules/nf-core/gawk/environment.yml' is unchanged
+'modules/nf-core/gawk/tests/main.nf.test' is unchanged
+'modules/nf-core/gawk/tests/nextflow.config' is unchanged
+'modules/nf-core/gawk/tests/main.nf.test.snap' is unchanged
+************************************************************

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -1,0 +1,70 @@
+process GAWK {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gawk:5.3.0' :
+        'biocontainers/gawk:5.3.0' }"
+
+    input:
+    tuple val(meta), path(input, arity: '0..*')
+    path(program_file)
+    val(disable_redirect_output)
+
+    output:
+    tuple val(meta), path("*.${suffix}"), emit: output
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args  = task.ext.args  ?: '' // args is used for the main arguments of the tool
+    def args2 = task.ext.args2 ?: '' // args2 is used to specify a program when no program file has been given
+    prefix    = task.ext.prefix ?: "${meta.id}"
+    suffix    = task.ext.suffix ?: "${input.collect{ it.getExtension()}.get(0)}" // use the first extension of the input files
+
+    program    = program_file ? "-f ${program_file}" : "${args2}"
+    lst_gz     = input.findResults{ it.getExtension().endsWith("gz") ? it.toString() : null }
+    unzip      = lst_gz ? "gunzip -q -f ${lst_gz.join(" ")}" : ""
+    input_cmd  = input.collect { it.toString() - ~/\.gz$/ }.join(" ")
+    output_cmd = suffix.endsWith("gz") ? "| gzip > ${prefix}.${suffix}" : "> ${prefix}.${suffix}"
+    output     = disable_redirect_output ? "" : output_cmd
+    cleanup    = lst_gz ? "rm ${lst_gz.collect{ it - ~/\.gz$/ }.join(" ")}" : ""
+
+    input.collect{
+        assert it.name != "${prefix}.${suffix}" : "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    }
+
+    """
+    ${unzip}
+
+    awk \\
+        ${args} \\
+        ${program} \\
+        ${input_cmd} \\
+        ${output}
+
+    ${cleanup}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = task.ext.suffix ?: "${input.getExtension()}"
+    def create_cmd = suffix.endsWith("gz") ? "echo '' | gzip >" : "touch"
+
+    """
+    ${create_cmd} ${prefix}.${suffix}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -8,7 +8,7 @@ process GAWK {
         'biocontainers/gawk:5.3.0' }"
 
     input:
-    tuple val(meta), path(input, arity: '0..*')
+    tuple val(meta), path(input)
     path(program_file)
     val(disable_redirect_output)
 

--- a/modules/nf-core/gawk/meta.yml
+++ b/modules/nf-core/gawk/meta.yml
@@ -1,0 +1,63 @@
+name: "gawk"
+description: |
+  If you are like many computer users, you would frequently like to make changes in various text files
+  wherever certain patterns appear, or extract data from parts of certain lines while discarding the rest.
+  The job is easy with awk, especially the GNU implementation gawk.
+keywords:
+  - gawk
+  - awk
+  - txt
+  - text
+  - file parsing
+tools:
+  - "gawk":
+      description: "GNU awk"
+      homepage: "https://www.gnu.org/software/gawk/"
+      documentation: "https://www.gnu.org/software/gawk/manual/"
+      tool_dev_url: "https://www.gnu.org/prep/ftp.html"
+      licence: ["GPL v3"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - input:
+        type: file
+        description: The input file - Specify the logic that needs to be executed on
+          this file on the `ext.args2` or in the program file.
+          If the files have a `.gz` extension, they will be unzipped using `zcat`.
+        pattern: "*"
+  - - program_file:
+        type: file
+        description: Optional file containing logic for awk to execute. If you don't
+          wish to use a file, you can use `ext.args2` to specify the logic.
+        pattern: "*"
+  - - disable_redirect_output:
+        type: boolean
+        description: Disable the redirection of awk output to a given file. This is
+          useful if you want to use awk's built-in redirect to write files instead
+          of the shell's redirect.
+output:
+  - output:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.${suffix}":
+          type: file
+          description: The output file - if using shell redirection, specify the name of this
+            file using `ext.prefix` and the extension using `ext.suffix`. Otherwise, ensure
+            the awk program produces files with the extension in `ext.suffix`.
+          pattern: "*"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@nvnieuwk"
+maintainers:
+  - "@nvnieuwk"

--- a/modules/nf-core/gawk/tests/main.nf.test
+++ b/modules/nf-core/gawk/tests/main.nf.test
@@ -1,0 +1,198 @@
+nextflow_process {
+
+    name "Test Process GAWK"
+    script "../main.nf"
+    process "GAWK"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gawk"
+
+    config "./nextflow.config"
+
+    test("Convert fasta to bed") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Convert fasta to bed with program file") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = Channel.of('BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Convert fasta to bed using awk redirect instead of shell redirect") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 > "test.bed" }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Extract first column from multiple files") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [file(params.modules_testdata_base_path + 'generic/txt/hello.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'generic/txt/species_names.txt', checkIfExists: true)]
+                ]
+                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Unzip files before processing") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/NA12878_chrM.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/NA24385_sv.vcf.gz', checkIfExists: true)]
+                ]
+                input[1] = Channel.of('/^#CHROM/ { print \$1, \$10 }').collectFile(name:"column_header.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Compress after processing") {
+        when {
+            params {
+                gawk_suffix = "txt.gz"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Input and output files are similar") {
+        when {
+            params {
+                gawk_suffix = "txt"
+                gawk_args   = ""
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'hello' ], // meta map
+                    [file(params.modules_testdata_base_path + 'generic/txt/hello.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'generic/txt/species_names.txt', checkIfExists: true)]
+                ]
+                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.failed },
+                { assert process.errorReport.contains("Input and output names are the same, set prefix in module configuration to disambiguate!") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gawk/tests/main.nf.test.snap
+++ b/modules/nf-core/gawk/tests/main.nf.test.snap
@@ -1,0 +1,200 @@
+{
+    "Compress after processing": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt.gz:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt.gz:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.1"
+        },
+        "timestamp": "2024-11-27T17:11:20.054143406"
+    },
+    "Convert fasta to bed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-19T13:14:02.347809811"
+    },
+    "Convert fasta to bed with program file": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-19T13:14:11.894616209"
+    },
+    "Extract first column from multiple files": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,566c51674bd643227bb2d83e0963376d"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,566c51674bd643227bb2d83e0963376d"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-19T22:04:47.729300129"
+    },
+    "Unzip files before processing": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,1e31ebd4a060aab5433bbbd9ab24e403"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,1e31ebd4a060aab5433bbbd9ab24e403"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-19T22:08:19.533527657"
+    },
+    "Convert fasta to bed using awk redirect instead of shell redirect": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-05T08:31:09.88842854"
+    }
+}

--- a/modules/nf-core/gawk/tests/nextflow.config
+++ b/modules/nf-core/gawk/tests/nextflow.config
@@ -1,0 +1,6 @@
+process {
+    withName: GAWK {
+        ext.suffix = params.gawk_suffix
+        ext.args2  = params.gawk_args2
+    }
+}

--- a/subworkflows/local/telo_finder.nf
+++ b/subworkflows/local/telo_finder.nf
@@ -4,7 +4,7 @@
 // MODULE IMPORT BLOCK
 //
 include { FIND_TELOMERE_REGIONS         } from '../../modules/local/find_telomere_regions'
-include { GAWK as GAWK_CLEAN_TELOMERE   } from '../../../modules/nf-core/gawk/main'
+include { GAWK as GAWK_CLEAN_TELOMERE   } from '../../modules/nf-core/gawk/main'
 include { FIND_TELOMERE_WINDOWS         } from '../../modules/local/find_telomere_windows'
 include { EXTRACT_TELO                  } from '../../modules/local/extract_telo'
 include { TABIX_BGZIPTABIX              } from '../../modules/nf-core/tabix/bgziptabix'

--- a/subworkflows/local/telo_finder.nf
+++ b/subworkflows/local/telo_finder.nf
@@ -3,6 +3,7 @@
 //
 // MODULE IMPORT BLOCK
 //
+include { GAWK as GAWK_UPPER_SEQUENCE   } from '../../modules/nf-core/gawk/main'
 include { FIND_TELOMERE_REGIONS         } from '../../modules/local/find_telomere_regions'
 include { GAWK as GAWK_CLEAN_TELOMERE   } from '../../modules/nf-core/gawk/main'
 include { FIND_TELOMERE_WINDOWS         } from '../../modules/local/find_telomere_windows'
@@ -19,10 +20,19 @@ workflow TELO_FINDER {
     ch_versions     = Channel.empty()
 
     //
+    // MODULE: UPPERCASE THE REFERENCE SEQUENCE
+    //
+    GAWK_UPPER_SEQUENCE(
+        reference_tuple,
+        [],
+        false,
+    )
+
+    //
     // MODULE: FINDS THE TELOMERIC SEQEUNCE IN REFERENCE
     //
     FIND_TELOMERE_REGIONS (
-        reference_tuple,
+        GAWK_UPPER_SEQUENCE.out.ouput,
         teloseq
     )
     ch_versions     = ch_versions.mix( FIND_TELOMERE_REGIONS.out.versions )

--- a/subworkflows/local/telo_finder.nf
+++ b/subworkflows/local/telo_finder.nf
@@ -27,12 +27,13 @@ workflow TELO_FINDER {
         [],
         false,
     )
+    ch_versions     = ch_versions.mix( GAWK_UPPER_SEQUENCE.out.versions )
 
     //
     // MODULE: FINDS THE TELOMERIC SEQEUNCE IN REFERENCE
     //
     FIND_TELOMERE_REGIONS (
-        GAWK_UPPER_SEQUENCE.out.ouput,
+        GAWK_UPPER_SEQUENCE.out.output,
         teloseq
     )
     ch_versions     = ch_versions.mix( FIND_TELOMERE_REGIONS.out.versions )


### PR DESCRIPTION
- Fix for telo subworkflow where using lowercase letters or bad motif may cause the program to add "you screwed up" into the output file. Added GAWK module to only keep lines starting with '>'
- Updated CHANGELOG