### PR TITLE
Fixes ahead of 1.4.1 release.

### DIFF
--- a/subworkflows/local/hic_mapping/main.nf
+++ b/subworkflows/local/hic_mapping/main.nf
@@ -140,7 +140,7 @@ workflow HIC_MAPPING {
             //
             // LOGIC: MAKE YAHS INPUT
             //
-            ref_yahs.map { meta, ref -> ref }.set{ch_ref}
+            reference_tuple.map { meta, ref -> ref }.set{ch_ref}
             reference_index.map { meta, fai -> fai }.set{ch_fai}
 
             //

--- a/workflows/treeval.nf
+++ b/workflows/treeval.nf
@@ -96,7 +96,7 @@ workflow TREEVAL {
     log.info "[Treeval: Info] PROCESSES TO RUN INCLUDE: $include_workflow_steps"
 
     // Validate that all requested steps are valid
-    def invalid_steps = exclude_steps_list - all_steps_list
+    invalid_steps = exclude_steps_list - all_steps_list
     if (invalid_steps) {
         log.error "[Treeval: Error] Invalid step(s) specified in --steps: ${invalid_steps.join(", ")}"
         log.error "[Treeval: Error] Valid options are: ${all_steps_list.join(", ")}"
@@ -104,7 +104,7 @@ workflow TREEVAL {
     }
 
     // Validate that include_workflow_steps contains only valid steps (safety check)
-    def invalid_include_steps = include_workflow_steps - all_steps_list
+    invalid_include_steps = include_workflow_steps - all_steps_list
     if (invalid_include_steps) {
         log.error "[Treeval: Error] Internal error - invalid workflow steps detected: ${invalid_include_steps.join(", ")}"
         System.exit(1)


### PR DESCRIPTION
- Removed unneeded def from main workflow
- Replaced ref_yahs with reference_tuple in hic_mapping
<!--
# sanger-tol/treeval pull request

Many thanks for contributing to sanger-tol/treeval!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/treeval/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
