### PR TITLE
docs: fix outdated YAML example links

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -200,7 +200,7 @@ This is all useful for the pipeline which generates job ids based on the org col
 
 Now let's use what we know to fill out the yaml.
 
-The yaml is a file that we need in order to tell the pipeline where everything is, an example can be found [here](https://raw.githubusercontent.com/sanger-tol/treeval/dev/assets/local_testing/nxOscDF5033.yaml).
+The yaml is a file that we need in order to tell the pipeline where everything is, an example can be found [here](../assets/local_testing/nxOscDF5033-BGA.yaml).
 
 ```yaml
 alignment:
@@ -315,7 +315,7 @@ YAML is "Yet Another Markdown Language", it is a human-readable format that we u
 
 ### YAML contents
 
-The following is an example YAML file we have used during production: [nxOscDF5033.yaml](../assets/local_testing/nxOscDF5033.yaml) and is shown below. This contains some annotations we believe to be helpful, information on the alignment, synteny, longread and hic data.
+The following is an example YAML file we have used during production: [nxOscDF5033-BGA.yaml](../assets/local_testing/nxOscDF5033-BGA.yaml) and is shown below. This contains some annotations we believe to be helpful, information on the alignment, synteny, longread and hic data.
 
 - `assembly`
   - `assem_level`: scaffold or contig level assembly (not used).


### PR DESCRIPTION
## Summary

Fixes #471

The documentation referenced YAML example files that no longer exist:

### Changes

1. **Line 203**: Updated link from broken `https://raw.githubusercontent.com/.../nxOscDF5033.yaml` to working relative path `../assets/local_testing/nxOscDF5033-BGA.yaml`

2. **Line 318**: Updated `[nxOscDF5033.yaml](../assets/local_testing/nxOscDF5033.yaml)` to `[nxOscDF5033-BGA.yaml](../assets/local_testing/nxOscDF5033-BGA.yaml)`

### Why

The actual file in the repository is `nxOscDF5033-BGA.yaml`, not `nxOscDF5033.yaml`. The old links returned 404 errors.

---
*Generated with Auto Bounty Hunter.*